### PR TITLE
Update README.md to point url to v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Example:
 ```
 @startuml
 
-!define SPRITESURL https://raw.githubusercontent.com/plantuml-stdlib/gilbarbara-plantuml-sprites/v1.0/sprites
+!define SPRITESURL https://raw.githubusercontent.com/plantuml-stdlib/gilbarbara-plantuml-sprites/v1.1/sprites
 !includeurl SPRITESURL/flask.puml
 !includeurl SPRITESURL/kafka.puml
 !includeurl SPRITESURL/kotlin.puml


### PR DESCRIPTION
**Issue**
Sprites that are in the list weren't available on the v1.0. 
E.g. pwa. 

**Fix**
Pointing to v1.1 in the documentation now.